### PR TITLE
Update analyzer in autoequal_gen

### DIFF
--- a/autoequal_gen/lib/src/generator.dart
+++ b/autoequal_gen/lib/src/generator.dart
@@ -87,5 +87,5 @@ class AutoequalGenerator extends GeneratorForAnnotation<Autoequal> {
   bool _isEquatable(ClassElement element) => _equatable.isSuperOf(element);
 
   bool _isWithEquatableMixin(ClassElement element) =>
-      element.mixins.any((type) => _equatableMixin.isExactly(type.element));
+      element.mixins.any((type) => _equatableMixin.isExactly(type.element2));
 }

--- a/autoequal_gen/pubspec.yaml
+++ b/autoequal_gen/pubspec.yaml
@@ -2,14 +2,14 @@ name: autoequal_gen
 description: |
   Codegenerator which can simplify work with 'equatable'.
   It will generate 'List<Object?> props' priviate extensions for all annotated classes.
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/sunnydaydev/autoequal
 
 environment:
   sdk: ">=2.17.0 <3.0.0"
 
 dependencies:
-  analyzer: ^4.7.0
+  analyzer: '>=4.7.0 <6.0.0'
   build: ^2.3.0
   source_gen: ^1.2.2
   autoequal: ^0.4.0


### PR DESCRIPTION
Addresses https://github.com/SunnyDayDev/autoequal/issues/7

I have updated

```yaml
analyzer: ^4.7.0
``` 

to

```yaml
analyzer: '>=4.7.0 <6.0.0'
```

In doing so I had also to update a removed getter `DartType.element` to `DartType.element2` in the [generator.dart](https://github.com/SunnyDayDev/autoequal/blob/main/autoequal_gen/lib/src/generator.dart#L90).

It's entirely backwards compatible with `analyzer: ^4.7.0` as `DartType.element2` got added in `v4.6.0`