### PR TITLE
:arrow_up: updates

### DIFF
--- a/autoequal/CHANGELOG.md
+++ b/autoequal/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+#### 0.6.0
+
+- Require Dart 3.0 or later
+- Add final modifier to annotation classes
+- Migrate from pedantic to lints
+- Update dependencies
+
 #### 0.5.1
 
 - Fixed use of `autoequal_gen` with `analyzer: 5.0.0`

--- a/autoequal/analysis_options.yaml
+++ b/autoequal/analysis_options.yaml
@@ -1,1 +1,6 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - "**.g.dart"
+    - "example/**"

--- a/autoequal/example/analysis_options.yaml
+++ b/autoequal/example/analysis_options.yaml
@@ -1,3 +1,0 @@
-analyzer:
-  exclude:
-   - main.dart

--- a/autoequal/lib/autoequal.dart
+++ b/autoequal/lib/autoequal.dart
@@ -1,3 +1,4 @@
 library autoequal;
 
 export 'src/public.dart';
+export 'src/src.dart';

--- a/autoequal/lib/src/src.dart
+++ b/autoequal/lib/src/src.dart
@@ -4,7 +4,7 @@ import 'package:meta/meta_meta.dart';
 /// to use it as value for List<Object> props of Equatable object.
 /// If mixin=true so a mixin with overrides 'List<Object> get props' will be additionally generated.
 @Target({TargetKind.classType})
-class Autoequal {
+final class Autoequal {
   final bool mixin;
 
   const Autoequal({this.mixin = false});
@@ -12,12 +12,12 @@ class Autoequal {
 
 /// Field marked with this annotation will be ignored
 @Target({TargetKind.field, TargetKind.getter})
-class IgnoreAutoequal {
+final class IgnoreAutoequal {
   const IgnoreAutoequal();
 }
 
 /// Field marked with this annotation will be included
 @Target({TargetKind.field, TargetKind.getter})
-class IncludeAutoequal {
+final class IncludeAutoequal {
   const IncludeAutoequal();
 }

--- a/autoequal/pubspec.yaml
+++ b/autoequal/pubspec.yaml
@@ -2,16 +2,16 @@ name: autoequal
 description: |
   Annotations for codegenerator 'autoequal_gen' to simplify work with 'equatable'.
   It will generate 'List<Object?> props' priviate extensions for all annotated classes.
-version: 0.5.1
+version: 0.6.0
 homepage: https://github.com/sunnydaydev/autoequal
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  meta: ^1.8.0
+  meta: ^1.9.1
 
 dev_dependencies:
   equatable: ^2.0.5
+  lints: ">=2.1.1 <4.0.0"
   test: ^1.21.5
-  pedantic: ^1.11.1

--- a/autoequal_gen/CHANGELOG.md
+++ b/autoequal_gen/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Changelog
 
+### 0.6.0
+
+- Require Dart 3.0 or later
+- Add final modifier to all classes
+- Migrate from pedantic to lints
+- Update dependencies
+
 #### 0.5.1
 
 - Fixed use of `autoequal_gen` with `analyzer: 5.0.0`

--- a/autoequal_gen/analysis_options.yaml
+++ b/autoequal_gen/analysis_options.yaml
@@ -1,1 +1,6 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
+
+analyzer:
+  exclude:
+    - "**.g.dart"
+    - "example/**"

--- a/autoequal_gen/lib/src/generator.dart
+++ b/autoequal_gen/lib/src/generator.dart
@@ -3,39 +3,39 @@ library generator;
 import 'dart:async';
 
 import 'package:analyzer/dart/element/element.dart';
-import 'package:autoequal/src/src.dart';
+import 'package:autoequal/autoequal.dart';
 import 'package:autoequal_gen/autoequal_gen.dart';
-import 'package:build/src/builder/build_step.dart';
+import 'package:build/build.dart';
 import 'package:equatable/equatable.dart';
 import 'package:source_gen/source_gen.dart';
 
 part 'template/extension.dart';
 part 'template/mixin.dart';
 
-const _equatable = TypeChecker.fromRuntime(Equatable);
-const _equatableMixin = TypeChecker.fromRuntime(EquatableMixin);
-const _ignore = TypeChecker.fromRuntime(IgnoreAutoequal);
-const _include = TypeChecker.fromRuntime(IncludeAutoequal);
+const TypeChecker _equatable = TypeChecker.fromRuntime(Equatable);
+const TypeChecker _equatableMixin = TypeChecker.fromRuntime(EquatableMixin);
+const TypeChecker _ignore = TypeChecker.fromRuntime(IgnoreAutoequal);
+const TypeChecker _include = TypeChecker.fromRuntime(IncludeAutoequal);
 
 /// For class marked with @Autoequal annotation will be generated properties list List<Object>
 /// to use it as value for List<Object> props of Equatable object.
 /// If mixin=true so a mixin with overrides 'List<Object> get props' will be additionally generated.
-class AutoequalGenerator extends GeneratorForAnnotation<Autoequal> {
+final class AutoequalGenerator extends GeneratorForAnnotation<Autoequal> {
   @override
   FutureOr<String> generateForAnnotatedElement(
       Element element, ConstantReader annotation, BuildStep buildStep) {
-    final classElement = _validateElement(element);
+    final ClassElement classElement = _validateElement(element);
 
-    final generated = <String>[];
+    final List<String> generated = [];
 
-    final isMixin = annotation.read('mixin').boolValue;
+    final bool isMixin = annotation.read('mixin').boolValue;
 
-    final mixin = _generateMixin(classElement, isMixin: isMixin);
+    final String? mixin = _generateMixin(classElement, isMixin: isMixin);
     if (mixin != null) {
       generated.add(mixin);
     }
 
-    final extension = _generateExtension(
+    final String extension = _generateExtension(
       classElement,
       includeDeprecated: mixin == null,
       isMixinAnnotation: isMixin,

--- a/autoequal_gen/lib/src/settings.dart
+++ b/autoequal_gen/lib/src/settings.dart
@@ -1,4 +1,4 @@
-class Settings {
+final class Settings {
   const Settings({
     required this.includeGetters,
   });

--- a/autoequal_gen/lib/src/template/extension.dart
+++ b/autoequal_gen/lib/src/template/extension.dart
@@ -1,6 +1,6 @@
-part of generator;
+part of '../generator.dart';
 
-class _AutoequalExtensionTemplate {
+final class _AutoequalExtensionTemplate {
   static String extensionName(String name) => '_\$${name}Autoequal';
 
   static String generate(
@@ -8,11 +8,12 @@ class _AutoequalExtensionTemplate {
     Iterable<String> props, {
     bool includeDeprecated = true,
   }) {
-    final extensionName = _AutoequalExtensionTemplate.extensionName(className);
+    final String extensionName =
+        _AutoequalExtensionTemplate.extensionName(className);
 
-    const deprecatedMessage = r"@Deprecated(r'Use _$props instead')";
+    const String deprecatedMessage = r"@Deprecated(r'Use _$props instead')";
 
-    const deprecated = '''
+    const String deprecated = '''
         $deprecatedMessage
         List<Object?> get _autoequalProps => _\$props;''';
 

--- a/autoequal_gen/lib/src/template/mixin.dart
+++ b/autoequal_gen/lib/src/template/mixin.dart
@@ -1,6 +1,6 @@
-part of generator;
+part of '../generator.dart';
 
-class _AutoequalMixinTemplate {
+final class _AutoequalMixinTemplate {
   static String mixinName(String className) => '_\$${className}AutoequalMixin';
 
   static String generate(
@@ -8,14 +8,15 @@ class _AutoequalMixinTemplate {
     String onTypeName, {
     required bool generateSuperProps,
   }) {
-    final mixinName = _AutoequalMixinTemplate.mixinName(className);
-    final extensionName = _AutoequalExtensionTemplate.extensionName(className);
+    final String mixinName = _AutoequalMixinTemplate.mixinName(className);
+    final String extensionName =
+        _AutoequalExtensionTemplate.extensionName(className);
 
-    final superProps = generateSuperProps ? '...super.props,' : '';
+    final String superProps = generateSuperProps ? '...super.props,' : '';
 
-    final open = generateSuperProps ? '[' : '';
-    final close = generateSuperProps ? ']' : '';
-    final spreadOp = generateSuperProps ? '...' : '';
+    final String open = generateSuperProps ? '[' : '';
+    final String close = generateSuperProps ? ']' : '';
+    final String spreadOp = generateSuperProps ? '...' : '';
 
     return '''
       mixin $mixinName on $onTypeName {

--- a/autoequal_gen/pubspec.yaml
+++ b/autoequal_gen/pubspec.yaml
@@ -2,21 +2,21 @@ name: autoequal_gen
 description: |
   Codegenerator which can simplify work with 'equatable'.
   It will generate 'List<Object?> props' priviate extensions for all annotated classes.
-version: 0.5.1
+version: 0.6.0
 homepage: https://github.com/sunnydaydev/autoequal
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  analyzer: '>=4.7.0 <6.0.0'
+  analyzer: '>=4.7.0 <7.0.0'
   build: ^2.3.0
   source_gen: ^1.2.2
-  autoequal: ^0.5.1
+  autoequal: ^0.6.0
   equatable: ^2.0.5
 
 dev_dependencies:
   build_test: ^2.1.5
   build_runner: ^2.2.0
+  lints: ">=2.1.1 <4.0.0"
   test: ^1.21.5
-  pedantic: ^1.11.1

--- a/test_project/analysis_options.yaml
+++ b/test_project/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
   exclude:

--- a/test_project/pubspec.yaml
+++ b/test_project/pubspec.yaml
@@ -3,17 +3,17 @@ description: Autoequal example
 version: 1.0.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  autoequal: ^0.5.1
+  autoequal: ^0.6.0
   equatable: ^2.0.5
 
 dev_dependencies:
-  pedantic: ^1.11.1
   build_runner: ^2.2.0
-  autoequal_gen: ^0.5.1
-  test: ^1.19.3
+  autoequal_gen: ^0.6.0
+  lints: ">=2.1.1 <4.0.0"
+  test: ^1.21.5
 
 dependency_overrides:
   autoequal:


### PR DESCRIPTION
- Bump version to 0.6.0
- Require Dart 3.0 or later
- Add final modifier to annotation classes
- Add final modifier to autoequal_generator classes
- Migrate from pedantic to lints
- Update dependencies