### PR TITLE
fix: lower path constraint to make compatible with flutter_test

### DIFF
--- a/autoequal/pubspec.yaml
+++ b/autoequal/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
-  meta: ^1.9.1
+  meta: ">=1.0.0 <2.0.0"
 
 dev_dependencies:
   equatable: ^2.0.5

--- a/autoequal_gen/pubspec.yaml
+++ b/autoequal_gen/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   dart_style: ^2.3.4
   meta: ">=1.0.0 <2.0.0"
   source_gen: ^1.4.0
-  path: ^1.9.0
+  path: ^1.8.3
   source_span: ^1.10.0
 
 dev_dependencies:


### PR DESCRIPTION
Fixes

```
Note: path is pinned to version 1.8.3 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because autoequal_gen >=0.9.0 depends on path ^1.9.0 and every version of flutter_test from sdk depends on path 1.8.3, autoequal_gen >=0.9.0 is incompatible with flutter_test from sdk.
So, because optox depends on both flutter_test from sdk and autoequal_gen ^0.9.0, version solving failed.
```

which prevents autoequal 0.9.0 from being used with Flutter 3.13 and 3.16.