### PR TITLE
chore: update dependencies

### DIFF
--- a/_core/pubspec.yaml
+++ b/_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: _core
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   json_annotation: ^4.8.1

--- a/autoequal/lib/autoequal.dart
+++ b/autoequal/lib/autoequal.dart
@@ -1,4 +1,4 @@
-library autoequal;
+library;
 
 export 'src/public.dart';
 export 'src/src.dart';

--- a/autoequal/pubspec.yaml
+++ b/autoequal/pubspec.yaml
@@ -7,12 +7,12 @@ homepage: https://github.com/mrgnhnt96/autoequal
 issue_tracker: https://github.com/mrgnhnt96/autoequal/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   meta: ^1.9.1
 
 dev_dependencies:
   equatable: ^2.0.5
-  lints: ">=2.1.1 <4.0.0"
+  lints: ">=3.0.0 <6.0.0"
   test: ^1.21.5

--- a/autoequal_gen/lib/autoequal_gen.dart
+++ b/autoequal_gen/lib/autoequal_gen.dart
@@ -1,4 +1,4 @@
-library autoequal_gen;
+library;
 
 import 'package:autoequal_gen/gen/settings.dart';
 import 'package:build/build.dart';

--- a/autoequal_gen/lib/src/generator.dart
+++ b/autoequal_gen/lib/src/generator.dart
@@ -1,4 +1,4 @@
-library generator;
+library;
 
 import 'dart:async' show FutureOr;
 
@@ -7,7 +7,6 @@ import 'package:autoequal_gen/src/visitors/class_visitor.dart';
 import 'package:autoequal_gen/src/writers/write_file.dart';
 import 'package:build/build.dart';
 import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:source_gen/source_gen.dart';
 
 /// For class marked with @Autoequal annotation will be generated properties list List<Object>
@@ -28,8 +27,6 @@ final class AutoequalGenerator extends Generator {
 
     final generated = writeFile(visitor.nodes);
 
-    final output = generated.map((e) => e.accept(emitter)).join('\n');
-
-    return DartFormatter().format(output);
+    return generated.map((e) => e.accept(emitter)).join('\n');
   }
 }

--- a/autoequal_gen/pubspec.yaml
+++ b/autoequal_gen/pubspec.yaml
@@ -7,17 +7,16 @@ homepage: https://github.com/mrgnhnt96/autoequal
 issue_tracker: https://github.com/mrgnhnt96/autoequal/issues
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
-  analyzer: ">=5.0.0 <7.0.0"
+  analyzer: ">=5.0.0 <8.0.0"
   autoequal: ">=0.1.0 <1.0.0"
   build: ^2.4.1
   code_builder: ^4.8.0
   change_case: ^2.0.1
-  dart_style: ^2.3.4
   meta: ">=1.0.0 <2.0.0"
-  source_gen: ^1.4.0
+  source_gen: ">=1.4.0 <3.0.0"
   path: ">=1.0.0 <2.0.0"
   source_span: ^1.10.0
 
@@ -26,5 +25,5 @@ dev_dependencies:
   build_test: ^2.2.1
   equatable: ^2.0.5
   generator_test: ^0.3.1
-  lints: ^3.0.0
+  lints: ">=3.0.0 <6.0.0"
   test: ^1.24.9

--- a/autoequal_gen/test/inputs/private_class.dart
+++ b/autoequal_gen/test/inputs/private_class.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 
+// ignore: unused_element
 class _Data extends Equatable {
   const _Data(this.one);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,10 +2,10 @@ name: _
 publish_to: "none"
 
 environment:
-  sdk: ">=2.17.0 <4.0.0"
+  sdk: ^3.0.0
 
 dev_dependencies:
   derry: ^1.5.0
-  very_good_cli: ^0.19.1
+  very_good_cli: ^0.25.0
 
 scripts: scripts.yaml

--- a/test_project/pubspec.yaml
+++ b/test_project/pubspec.yaml
@@ -5,7 +5,7 @@ version: 1.0.0
 publish_to: "none"
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.0.0
 
 dependencies:
   autoequal:
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^2.4.7
   autoequal_gen:
-  lints: ^3.0.0
+  lints: ">=3.0.0 <6.0.0"
   test: ^1.24.9
   derry: ^1.5.0
   generator_test: ^0.3.1


### PR DESCRIPTION
This pull request includes several changes to update SDK constraints, dependencies, and library declarations across multiple files. The most important changes are grouped by theme below:

### SDK and Dependency Updates:
* Updated SDK constraints to `^3.0.0` in `pubspec.yaml` files for `_core`, `autoequal`, `autoequal_gen`, and `test_project` packages. [[1]](diffhunk://#diff-9fb6d89714f887fdc08916ed84b9605267e1a184962b85da3b75bfd33f2b691cL5-R5) [[2]](diffhunk://#diff-67294b8f54ffd9ddb62a9356652dfe01a0ff1f1c556408b8e637b1df0e9748bcL10-R17) [[3]](diffhunk://#diff-11b532b634802395787f2370ccaff663bf82dca6977d9972cbef68c2a32c5a84L10-R19) [[4]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L5-R9) [[5]](diffhunk://#diff-d75e56108bef22f44bb566066c0a850c200e3e5d164b0a424a54b59ddb856ac4L8-R8)
* Updated dependency versions for `lints` and other dependencies in `pubspec.yaml` files for `autoequal`, `autoequal_gen`, and `test_project` packages. [[1]](diffhunk://#diff-67294b8f54ffd9ddb62a9356652dfe01a0ff1f1c556408b8e637b1df0e9748bcL10-R17) [[2]](diffhunk://#diff-11b532b634802395787f2370ccaff663bf82dca6977d9972cbef68c2a32c5a84L29-R28) [[3]](diffhunk://#diff-d75e56108bef22f44bb566066c0a850c200e3e5d164b0a424a54b59ddb856ac4L17-R17)

### Library Declarations:
* Removed the library name declarations from Dart files in the `autoequal`, `autoequal_gen`, and `autoequal_gen/src` directories. [[1]](diffhunk://#diff-6e81bb1b6011d4efcbea990d7010db7267590d946022174ed80ef6551d8d6380L1-R1) [[2]](diffhunk://#diff-b78cb97fdcb4b1833fda98e85e0f148bb25e7c9c0075ca68247177bee6d01f1fL1-R1) [[3]](diffhunk://#diff-232d238828661525634fe56a3dfdff3756187574a226a0adf7991a969a7dc8dfL1-R1)

### Code Simplification:
* Removed the usage of `DartFormatter` in the `AutoequalGenerator` class in `autoequal_gen/lib/src/generator.dart`.

### Miscellaneous:
* Removed the `dart_style` dependency from `autoequal_gen/pubspec.yaml`. [[1]](diffhunk://#diff-232d238828661525634fe56a3dfdff3756187574a226a0adf7991a969a7dc8dfL10) [[2]](diffhunk://#diff-11b532b634802395787f2370ccaff663bf82dca6977d9972cbef68c2a32c5a84L10-R19)
* Added an ignore comment for an unused element in `autoequal_gen/test/inputs/private_class.dart`.